### PR TITLE
Rename helper types

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class Foo(TypedDict):
   foo: List[float]
   optional: NotRequired[Optional[str]]
 
-class __HelperType1__(TypedDict):
+class Ts2PyHelperType1(TypedDict):
   foo: Foo
 
 class Bar(TypedDict):
@@ -54,7 +54,7 @@ class Bar(TypedDict):
   """
   type: Literal["bar"]
   bar: str
-  nested: __HelperType1__
+  nested: Ts2PyHelperType1
   """
   nested objects need extra declarations in Python
   """

--- a/src/isValidPythonIdentifier.ts
+++ b/src/isValidPythonIdentifier.ts
@@ -1,0 +1,5 @@
+const validNameRegex = /^[a-zA-Z_][\w]*$/;
+
+export const isValidPythonIdentifier = (name: string) => {
+  return !!name.match(validNameRegex);
+};

--- a/src/newHelperTypeName.ts
+++ b/src/newHelperTypeName.ts
@@ -3,5 +3,5 @@ import * as ts from "typescript";
 
 export const newHelperTypeName = (state: ParserState, type?: ts.Type) => {
   const typeName = type?.aliasSymbol?.getName() ?? "";
-  return `__HelperType${++state.helperCount}__${typeName}`;
+  return `Ts2Py${typeName}HelperType${++state.helperCount}`;
 };

--- a/src/parseTypeDefinition.ts
+++ b/src/parseTypeDefinition.ts
@@ -3,8 +3,7 @@ import { ParserState } from "./ParserState";
 import { parseProperty } from "./parseProperty";
 import { getDocumentationStringForType } from "./getDocumentationStringForType";
 import { tryToParseInlineType } from "./parseInlineType";
-
-const validNameRegex = /^[a-zA-Z_$][\w$]*$/;
+import { isValidPythonIdentifier } from "./isValidPythonIdentifier";
 
 export const parseTypeDefinition = (
   state: ParserState,
@@ -26,7 +25,7 @@ export const parseTypeDefinition = (
   } else {
     const properties = type
       .getProperties()
-      .filter((v) => v.getName().match(validNameRegex))
+      .filter((v) => isValidPythonIdentifier(v.getName()))
       .map((v) => parseProperty(state, v));
 
     return `class ${name}(TypedDict):${

--- a/src/testing/.ts
+++ b/src/testing/.ts
@@ -43,7 +43,7 @@ describe("transpiling dictionaries types", () => {
       extra: number,
     }`);
     expect(result).toContain(
-`class __HelperType1__(TypedDict):
+`class Ts2Py(HelperType1TypedDict):
   inner: str
 
 class A(TypedDict):

--- a/src/testing/dicts.test.ts
+++ b/src/testing/dicts.test.ts
@@ -43,11 +43,11 @@ describe("transpiling dictionaries types", () => {
       extra: number,
     }`);
     expect(result).toContain(
-      `class __HelperType1__(TypedDict):
+      `class Ts2PyHelperType1(TypedDict):
   inner: str
 
 class A(TypedDict):
-  outer: __HelperType1__
+  outer: Ts2PyHelperType1
   extra: float`,
     );
   });

--- a/src/testing/imports.test.ts
+++ b/src/testing/imports.test.ts
@@ -28,11 +28,11 @@ describe("transpiling referenced types", () => {
     expect(transpiled).toEqual(
       `from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any
 
-class __HelperType1__Foo(TypedDict):
+class Ts2PyFooHelperType1(TypedDict):
   foo: float
 
 class Bar(TypedDict):
-  foo: __HelperType1__Foo`,
+  foo: Ts2PyFooHelperType1`,
     );
   });
 });

--- a/src/testing/reference.test.ts
+++ b/src/testing/reference.test.ts
@@ -10,15 +10,15 @@ describe("transpiling referenced types", () => {
     expect(result).toEqual(
       `from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any
 
-class __HelperType1__A(TypedDict):
+class Ts2PyAHelperType1(TypedDict):
   foo: float
 
-class __HelperType2__(TypedDict):
+class Ts2PyHelperType2(TypedDict):
   bar: str
 
 class C(TypedDict):
   flat: float
-  outer: Union[__HelperType1__A,Dict[str,bool],__HelperType2__]`,
+  outer: Union[Ts2PyAHelperType1,Dict[str,bool],Ts2PyHelperType2]`,
     );
   });
 });


### PR DESCRIPTION
As it turns out, Python does not like types and properties starting with double underscore (`__`), resulting in mangled type names. This changes the generated helper type names to not introduce underscores.