### PR TITLE
revert to defining generics, but as object, to avoid missing declarations

### DIFF
--- a/src/parseInlineType.ts
+++ b/src/parseInlineType.ts
@@ -21,6 +21,9 @@ export const tryToParseInlineType = (
   
   if (known !== undefined) {
     return known;
+  } else if (type.getFlags() & (ts.TypeFlags.TypeParameter | ts.TypeFlags.TypeVariable)) {
+    // we don't support types with generic type parameters
+    return `object`;
   } else if (type.isLiteral()) {
     return `Literal[${JSON.stringify(type.value)}]`;
   } else if (type.isUnion()) {

--- a/src/parseTypeDefinition.ts
+++ b/src/parseTypeDefinition.ts
@@ -10,12 +10,6 @@ export const parseTypeDefinition = (
   name: string,
   type: ts.Type,
 ) => {
-  
-  if ((type.getFlags() & ts.TypeFlags.TypeParameter) !== 0) {
-    // we don't support types with generic type parameters
-    return;
-  }
-
   const inlineType = tryToParseInlineType(state, type, true);
   const documentation = getDocumentationStringForType(state.typechecker, type);
 

--- a/src/testing/generics.test.ts
+++ b/src/testing/generics.test.ts
@@ -5,7 +5,7 @@ describe("transpiling generic types", () => {
     const transpiled = await transpileString(
       `export type Generic<T extends string> = T;`,
     );
-    expect(transpiled).not.toContain("Generic");
+    expect(transpiled).toContain("Generic = object");
   });
 
   it("does transpile fully narrowed generic types", async () => {
@@ -13,7 +13,7 @@ describe("transpiling generic types", () => {
       export type Generic<T extends string> = T;
       export type Narrowed = Generic<string>;
     `);
-    expect(transpiled).not.toContain("Generic");
+    expect(transpiled).toContain("Generic = object");
     expect(transpiled).toContain("Narrowed = str");
   });
 });


### PR DESCRIPTION
Fixes an issue introduced by #4, that might result in broken source files due to incomplete declarations.
This fixes the issue by still defining type variables, but as the "unknown" `object` type instead.
