### PR TITLE
Re-use helper types if possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,14 @@ export type Bar = {
 export type FooBarMap = { 
     [key: string]: Foo | Bar
 }
+
+export type Tuple = [string, Foo | Bar, any[]]
 ```
 
 ### TypeScript2Python
 
 ```python
-from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any
+from typing_extensions import Any, Dict, List, Literal, NotRequired, Optional, Tuple, TypedDict, Union
 
 class Foo(TypedDict):
   type: Literal["foo"]
@@ -60,6 +62,8 @@ class Bar(TypedDict):
   """
 
 FooBarMap = Dict[str,Union[Foo,Bar]]
+
+Tuple = Tuple[str,Union[Foo,Bar],List[Any]]
 ```
 
 

--- a/src/ParserState.ts
+++ b/src/ParserState.ts
@@ -1,8 +1,26 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 export type ParserState = {
   helperCount: number;
   statements: string[];
   typechecker: ts.TypeChecker;
-  knownTypes: Map<ts.Type, string>;
+  knownTypes: Map<ts.Type | string, string>;
+  imports: Set<string>;
 };
+
+export const createNewParserState = (typechecker: ts.TypeChecker): ParserState => {
+  const knownTypes = new Map<ts.Type, string>();
+  knownTypes.set(typechecker.getVoidType(), "None");
+  knownTypes.set(typechecker.getUndefinedType(), "None");
+  knownTypes.set(typechecker.getStringType(), "str");
+  knownTypes.set(typechecker.getBooleanType(), "bool");
+  knownTypes.set(typechecker.getNumberType(), "float");
+
+  return {
+    statements: [],
+    helperCount: 0,
+    typechecker,
+    knownTypes,
+    imports: new Set(),
+  };
+}

--- a/src/getDocumentationStringForType.ts
+++ b/src/getDocumentationStringForType.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 
 export const getDocumentationStringForType = (
   typechecker: ts.TypeChecker,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as ts from "typescript";
+import ts from "typescript";
 import path from "path";
 import { program } from "@commander-js/extra-typings";
 import { typeScriptToPython } from "./typeScriptToPython";

--- a/src/newHelperTypeName.ts
+++ b/src/newHelperTypeName.ts
@@ -1,5 +1,5 @@
 import { ParserState } from "./ParserState";
-import * as ts from "typescript";
+import ts from "typescript";
 
 export const newHelperTypeName = (state: ParserState, type?: ts.Type) => {
   const typeName = type?.aliasSymbol?.getName() ?? "";

--- a/src/parseExports.ts
+++ b/src/parseExports.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { ParserState } from "./ParserState";
 import { parseTypeDefinition } from "./parseTypeDefinition";
 

--- a/src/parseInlineType.ts
+++ b/src/parseInlineType.ts
@@ -1,5 +1,5 @@
-import * as ts from "typescript";
-import { ParserState } from "./ParserState";
+import ts from "typescript";
+import { ParserState, createNewParserState } from "./ParserState";
 import { newHelperTypeName } from "./newHelperTypeName";
 import { parseTypeDefinition } from "./parseTypeDefinition";
 
@@ -12,6 +12,18 @@ export const parseInlineType = (state: ParserState, type: ts.Type) => {
   }
 };
 
+/** 
+ * A function that creates a unique string for a given interface or object type,
+ * from a fresh parser state. This should return the same string for two semantically
+ * identically types, allowing us to re-use existing helper types if the generated
+ * strings match. 
+ **/
+const getCanonicalTypeName = (state: ParserState, type: ts.Type) => {
+  const tmpState = createNewParserState(state.typechecker);
+  parseTypeDefinition(tmpState, "TS2PyTmpType", type);
+  return tmpState.statements.join("\n")
+}
+
 export const tryToParseInlineType = (
   state: ParserState,
   type: ts.Type,
@@ -21,38 +33,61 @@ export const tryToParseInlineType = (
   
   if (known !== undefined) {
     return known;
+  } else if (type === state.typechecker.getTrueType()) {
+    state.imports.add("Literal");
+    return "Literal[True]"
+  } else if (type === state.typechecker.getFalseType()) {
+    state.imports.add("Literal");
+    return "Literal[False]"
+  } else if (type === state.typechecker.getAnyType()) {
+    state.imports.add("Any");
+    return "Any";
   } else if (type.getFlags() & (ts.TypeFlags.TypeParameter | ts.TypeFlags.TypeVariable)) {
     // we don't support types with generic type parameters
     return `object`;
   } else if (type.isLiteral()) {
+    state.imports.add("Literal");
     return `Literal[${JSON.stringify(type.value)}]`;
   } else if (type.isUnion()) {
+    state.imports.add("Union");
     return `Union[${type.types
       .map((v) => parseInlineType(state, v))
       .join(",")}]`;
   } else if (state.typechecker.isTupleType(type)) {
+    state.imports.add("Tuple");
     return `Tuple[${state.typechecker
       .getTypeArguments(type as ts.TypeReference)
       .map((v) => parseInlineType(state, v))
       .join(",")}]`;
   } else if (type.getStringIndexType() !== undefined) {
+    state.imports.add("Dict");
     return `Dict[str,${parseInlineType(state, type.getStringIndexType()!)}]`;
   } else if (state.typechecker.isArrayLikeType(type)) {
     const typeArguments = state.typechecker.getTypeArguments(
       type as ts.TypeReference,
     );
     if (typeArguments.length === 1) {
+      state.imports.add("List");
       return `List[${parseInlineType(state, typeArguments[0]!)}]`;
     } else {
       // TODO: figure out why we reach this and replace with correct type definition
       return `object`;
     }
   } else {
-    // assume interface or object
+    // assume interface or object, we need to create a helper type
     if (!globalScope) {
-      const helperName = newHelperTypeName(state, type);
-      parseTypeDefinition(state, helperName, type);
-      return helperName;
+      const canonicalName = getCanonicalTypeName(state, type);
+      const semanticallyIdenticalType = state.knownTypes.get(canonicalName);
+      if (semanticallyIdenticalType !== undefined) {
+        // we can re-use an existing helper type
+        return semanticallyIdenticalType;
+      } else {
+        // we must create a new type
+        const helperName = newHelperTypeName(state, type);
+        parseTypeDefinition(state, helperName, type);
+        state.knownTypes.set(canonicalName, helperName);
+        return helperName;
+      }
     } else {
       // type cannot be defined inline
       return undefined;

--- a/src/parseProperty.ts
+++ b/src/parseProperty.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { ParserState } from "./ParserState";
 import { parseInlineType } from "./parseInlineType";
 
@@ -17,6 +17,8 @@ export const parseProperty = (state: ParserState, symbol: ts.Symbol) => {
   );
 
   if (symbol.flags & ts.SymbolFlags.Optional) {
+    state.imports.add("NotRequired");
+    state.imports.add("Optional");
     return `${name}: NotRequired[Optional[${definition}]]${documentationSuffix}`;
   } else {
     return `${name}: ${definition}${documentationSuffix}`;

--- a/src/parseTypeDefinition.ts
+++ b/src/parseTypeDefinition.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import ts from "typescript";
 import { ParserState } from "./ParserState";
 import { parseProperty } from "./parseProperty";
 import { getDocumentationStringForType } from "./getDocumentationStringForType";
@@ -24,6 +24,8 @@ export const parseTypeDefinition = (
     }`;
     state.statements.push(definition);
   } else {
+    state.imports.add("TypedDict");
+
     const properties = type
       .getProperties()
       .filter((v) => isValidPythonIdentifier(v.getName()))

--- a/src/testing/basic.test.ts
+++ b/src/testing/basic.test.ts
@@ -2,30 +2,59 @@ import { transpileString } from "./utils";
 
 describe("transpiling basic types", () => {
   it.each([
-    ["export type T = any;", "T = Any"],
     ["export type T = boolean;", "T = bool"],
     ["export type T = number;", "T = float"],
     ["export type T = string;", "T = str"],
     ["export type T = undefined;", "T = None"],
     ["export type T = void;", "T = None"],
-    ["export type T = true;", "T = Literal[True]"],
-    ["export type T = false;", "T = Literal[False]"],
-    ["export type T = 42;", "T = Literal[42]"],
-    ["export type T = 'foo';", 'T = Literal["foo"]'],
-    ["export type T = {[key: string]: boolean};", "T = Dict[str,bool]"],
-    ["export type T = {[key: string]: number};", "T = Dict[str,float]"],
+    [
+      "export type T = true;",
+      "from typing_extensions import Literal\n\nT = Literal[True]",
+    ],
+    [
+      "export type T = false;",
+      "from typing_extensions import Literal\n\nT = Literal[False]",
+    ],
+    [
+      "export type T = 42;",
+      "from typing_extensions import Literal\n\nT = Literal[42]",
+    ],
+    [
+      "export type T = 'foo';",
+      'from typing_extensions import Literal\n\nT = Literal["foo"]',
+    ],
+    [
+      "export type T = {[key: string]: boolean};",
+      "from typing_extensions import Dict\n\nT = Dict[str,bool]",
+    ],
+    [
+      "export type T = {[key: string]: number};",
+      "from typing_extensions import Dict\n\nT = Dict[str,float]",
+    ],
+    [
+      "export type T = [string, number]",
+      "from typing_extensions import Tuple\n\nT = Tuple[str,float]",
+    ],
+    [
+      "export type T = number[]",
+      "from typing_extensions import List\n\nT = List[float]",
+    ],
+    ["export type T = any;", "from typing_extensions import Any\n\nT = Any"],
     [
       "export type T = {[key: string]: {[key: string]: number}};",
-      "T = Dict[str,Dict[str,float]]",
+      "from typing_extensions import Dict\n\nT = Dict[str,Dict[str,float]]",
     ],
-    ["export type T = Record<string, number>;", "T = Dict[str,float]"],
+    [
+      "export type T = Record<string, number>;",
+      "from typing_extensions import Dict\n\nT = Dict[str,float]",
+    ],
     [
       "export type T = number | string | Record<string, boolean>",
-      "T = Union[str,float,Dict[str,bool]]",
+      "from typing_extensions import Dict, Union\n\nT = Union[str,float,Dict[str,bool]]",
     ],
   ])("transpiles %p to %p", async (input, expected) => {
     const result = await transpileString(input);
-    expect(result.split("\n")[2]).toEqual(expected);
+    expect(result).toEqual(expected);
   });
 
   it("only transpiles exported types", async () => {

--- a/src/testing/helperTypes.test.ts
+++ b/src/testing/helperTypes.test.ts
@@ -1,0 +1,47 @@
+import { transpileString } from "./utils";
+
+describe("creating helper types", () => {
+  it("converts nested types to helper types", async () => {
+    const result = await transpileString(`
+      export type T = { inner: { foo: { bar: string } } }
+    `);
+
+    expect(result).toEqual(
+      `from typing_extensions import TypedDict
+
+class Ts2PyHelperType2(TypedDict):
+  bar: str
+
+class Ts2PyHelperType1(TypedDict):
+  foo: Ts2PyHelperType2
+
+class T(TypedDict):
+  inner: Ts2PyHelperType1`,
+    );
+  });
+
+  it("reuses identical helper types", async () => {
+    const result = await transpileString(`
+      export type A = { a: { foo: { bar: string } } }
+      export type B = { b: { foo: { bar: string } } }
+      export type C = { foo: { bar: string } }
+    `);
+
+    expect(result).toEqual(`from typing_extensions import TypedDict
+
+class Ts2PyHelperType2(TypedDict):
+  bar: str
+
+class Ts2PyHelperType1(TypedDict):
+  foo: Ts2PyHelperType2
+
+class A(TypedDict):
+  a: Ts2PyHelperType1
+
+class B(TypedDict):
+  b: Ts2PyHelperType1
+
+class C(TypedDict):
+  foo: Ts2PyHelperType2`);
+  });
+});

--- a/src/testing/imports.test.ts
+++ b/src/testing/imports.test.ts
@@ -26,7 +26,7 @@ describe("transpiling referenced types", () => {
       barSource,
     ]);
     expect(transpiled).toEqual(
-      `from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any
+      `from typing_extensions import TypedDict
 
 class Ts2PyFooHelperType1(TypedDict):
   foo: float

--- a/src/testing/reference.test.ts
+++ b/src/testing/reference.test.ts
@@ -8,7 +8,7 @@ describe("transpiling referenced types", () => {
       export type C = { flat: number, outer: B }
     `);
     expect(result).toEqual(
-      `from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any
+      `from typing_extensions import Dict, TypedDict, Union
 
 class Ts2PyAHelperType1(TypedDict):
   foo: float

--- a/src/typeScriptToPython.ts
+++ b/src/typeScriptToPython.ts
@@ -1,35 +1,21 @@
-import * as ts from "typescript";
-import { ParserState } from "./ParserState";
+import ts from "typescript";
+import { ParserState, createNewParserState } from "./ParserState";
 import { parseExports } from "./parseExports";
 
 /**
  * Transpiles the types exported by the source files into Python.
  */
 export const typeScriptToPython = (typechecker: ts.TypeChecker, sourceFiles: ts.SourceFile[]) => {
-  const knownTypes = new Map<ts.Type, string>();
-  knownTypes.set(typechecker.getAnyType(), "Any");
-  knownTypes.set(typechecker.getVoidType(), "None");
-  knownTypes.set(typechecker.getUndefinedType(), "None");
-  knownTypes.set(typechecker.getStringType(), "str");
-  knownTypes.set(typechecker.getBooleanType(), "bool");
-  knownTypes.set(typechecker.getNumberType(), "float");
-  knownTypes.set(typechecker.getTrueType(), "Literal[True]");
-  knownTypes.set(typechecker.getFalseType(), "Literal[False]");
-
-  const state: ParserState = {
-    statements: [],
-    helperCount: 0,
-    typechecker,
-    knownTypes,
-  };
-
-  state.statements.push(
-    `from typing_extensions import Literal, TypedDict, List, Union, NotRequired, Optional, Tuple, Dict, Any`
-  );
+  const state = createNewParserState(typechecker);
 
   sourceFiles.forEach((f) => {
     parseExports(state, f);
   });
 
-  return state.statements.join("\n\n");
+  let importStatement = ""
+  if (state.imports.size > 0) {
+    importStatement = `from typing_extensions import ${Array.from(state.imports).sort().join(", ")}\n\n`
+  }
+
+  return importStatement + state.statements.join("\n\n");
 };


### PR DESCRIPTION
Previously, it could happen that multiple identical helper types were defined. This adds a new function `getCanonicalTypeName` that allows us to determine if we've already created a specific helper type and re-use it if so. Also we've refactored the imports so that only used definitions are imported from `typing_extensions`.
