### PR TITLE
Update example to avoid naming conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export type FooBarMap = {
     [key: string]: Foo | Bar
 }
 
-export type Tuple = [string, Foo | Bar, any[]]
+export type TupleType = [string, Foo | Bar, any[]]
 ```
 
 ### TypeScript2Python
@@ -63,7 +63,7 @@ class Bar(TypedDict):
 
 FooBarMap = Dict[str,Union[Foo,Bar]]
 
-Tuple = Tuple[str,Union[Foo,Bar],List[Any]]
+TupleType = Tuple[str,Union[Foo,Bar],List[Any]]
 ```
 
 


### PR DESCRIPTION
Previously, the example would use a name `Tuple` for a TypeScript, which actually conflicts with the import `Tuple` in Python. This PR updates the example code so that there is no naming conflict. In the future we might consider renaming the import in such cases.