### PR TITLE
add support for unknown type

### DIFF
--- a/src/parseInlineType.ts
+++ b/src/parseInlineType.ts
@@ -1,4 +1,4 @@
-import ts from "typescript";
+import ts, { TypeFlags } from "typescript";
 import { ParserState, createNewParserState } from "./ParserState";
 import { newHelperTypeName } from "./newHelperTypeName";
 import { parseTypeDefinition } from "./parseTypeDefinition";
@@ -39,7 +39,7 @@ export const tryToParseInlineType = (
   } else if (type === state.typechecker.getFalseType()) {
     state.imports.add("Literal");
     return "Literal[False]"
-  } else if (type === state.typechecker.getAnyType()) {
+  } else if (type === state.typechecker.getAnyType() || ((type.flags & TypeFlags.Unknown) !== 0)) {
     state.imports.add("Any");
     return "Any";
   } else if (type.getFlags() & (ts.TypeFlags.TypeParameter | ts.TypeFlags.TypeVariable)) {

--- a/src/testing/basic.test.ts
+++ b/src/testing/basic.test.ts
@@ -41,6 +41,10 @@ describe("transpiling basic types", () => {
     ],
     ["export type T = any;", "from typing_extensions import Any\n\nT = Any"],
     [
+      "export type T = unknown;",
+      "from typing_extensions import Any\n\nT = Any",
+    ],
+    [
       "export type T = {[key: string]: {[key: string]: number}};",
       "from typing_extensions import Dict\n\nT = Dict[str,Dict[str,float]]",
     ],


### PR DESCRIPTION
We add support for the `unknown` type by treating it the same way as `any` as `unknown` does not seem to have an equivalent in Python typings.