### PR TITLE
BREAKING CHANGE: make optional dict values non-nullable by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from typing_extensions import Any, Dict, List, Literal, NotRequired, Optional, T
 class Foo(TypedDict):
   type: Literal["foo"]
   foo: List[float]
-  optional: NotRequired[Optional[str]]
+  optional: NotRequired[str]
 
 class Ts2PyHelperType1(TypedDict):
   foo: Foo
@@ -89,8 +89,15 @@ TypeScript2Python supports many of TypeScripts type constructs, including:
 - Unions, `string | number`
 - Arrays, `boolean[]`
 - Nested objects `{ bar: { foo: string } }`, that will get transpiled into helper dictionaries
-- Optional properties `{ optional?: number }`, that get transpiled to `NotRequired[Optional[...]]` attributes
+- Optional properties `{ optional?: number }`, that get transpiled to `NotRequired[...]` attributes
 - Docstrings `/** this is very useful */`
+
+## Transpilation options
+
+### Nullable optionals
+
+In TypeScript objects, optional values can also be set to `undefined`. By default we assume the according Python
+type to be non-nullable, but a more closely matching behavior can be achieved using the flag `--nullable-optionals`.  
 
 ## Limitations
 

--- a/src/ParserState.ts
+++ b/src/ParserState.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { Ts2PyConfig } from "./config";
 
 export type ParserState = {
   helperCount: number;
@@ -6,9 +7,10 @@ export type ParserState = {
   typechecker: ts.TypeChecker;
   knownTypes: Map<ts.Type | string, string>;
   imports: Set<string>;
+  config: Ts2PyConfig;
 };
 
-export const createNewParserState = (typechecker: ts.TypeChecker): ParserState => {
+export const createNewParserState = (typechecker: ts.TypeChecker, config: Ts2PyConfig): ParserState => {
   const knownTypes = new Map<ts.Type, string>();
   knownTypes.set(typechecker.getVoidType(), "None");
   knownTypes.set(typechecker.getUndefinedType(), "None");
@@ -22,5 +24,6 @@ export const createNewParserState = (typechecker: ts.TypeChecker): ParserState =
     typechecker,
     knownTypes,
     imports: new Set(),
+    config,
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 
 export type Ts2PyConfig = {
-    nonNullOptionals?: boolean;
+    nullableOptionals?: boolean;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,4 @@
+
+export type Ts2PyConfig = {
+    nonNullOptionals?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ const compile = (fileNames: string[], config: Ts2PyConfig) => {
 program
   .name("typescript2python")
   .description("A program that converts TypeScript type definitions to Python")
-  .option("--non-null-optionals", "if set, optional entries in dictionaries will not be `NotRequired[T]` instead of `NotRequired[Optional[T]]`")
+  .option("--nullable-optionals", "if set, optional entries in dictionaries will be nullable, e.g. `NotRequired[Optional[T]]`")
   .arguments("<input...>")
   .action((args, options) => {
     compile(args, options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ import ts from "typescript";
 import path from "path";
 import { program } from "@commander-js/extra-typings";
 import { typeScriptToPython } from "./typeScriptToPython";
+import { Ts2PyConfig } from "./config";
 
-const compile = (fileNames: string[]) => {
+const compile = (fileNames: string[], config: Ts2PyConfig) => {
   const program = ts.createProgram(fileNames, {
     noEmit: true,
     allowJs: true,
@@ -21,16 +22,17 @@ const compile = (fileNames: string[]) => {
         .reduce((a, b) => a || b),
     );
 
-  const transpiled = typeScriptToPython(program.getTypeChecker(), relevantSourceFiles)
+  const transpiled = typeScriptToPython(program.getTypeChecker(), relevantSourceFiles, config)
   console.log(transpiled);
 }
 
 program
   .name("typescript2python")
   .description("A program that converts TypeScript type definitions to Python")
+  .option("--non-null-optionals", "if set, optional entries in dictionaries will not be `NotRequired[T]` instead of `NotRequired[Optional[T]]`")
   .arguments("<input...>")
-  .action(args => {
-    compile(args)
+  .action((args, options) => {
+    compile(args, options)
   })
   .parse(process.argv)
 

--- a/src/parseExports.ts
+++ b/src/parseExports.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { ParserState } from "./ParserState";
 import { parseTypeDefinition } from "./parseTypeDefinition";
+import { Ts2PyConfig } from "./config";
 
 export function parseExports(state: ParserState, sourceFile: ts.SourceFile) {
   for (const statement of sourceFile.statements) {

--- a/src/parseInlineType.ts
+++ b/src/parseInlineType.ts
@@ -19,7 +19,7 @@ export const parseInlineType = (state: ParserState, type: ts.Type) => {
  * strings match. 
  **/
 const getCanonicalTypeName = (state: ParserState, type: ts.Type) => {
-  const tmpState = createNewParserState(state.typechecker);
+  const tmpState = createNewParserState(state.typechecker, state.config);
   parseTypeDefinition(tmpState, "TS2PyTmpType", type);
   return tmpState.statements.join("\n")
 }

--- a/src/parseProperty.ts
+++ b/src/parseProperty.ts
@@ -18,8 +18,12 @@ export const parseProperty = (state: ParserState, symbol: ts.Symbol) => {
 
   if (symbol.flags & ts.SymbolFlags.Optional) {
     state.imports.add("NotRequired");
-    state.imports.add("Optional");
-    return `${name}: NotRequired[Optional[${definition}]]${documentationSuffix}`;
+    if (state.config.nonNullOptionals) {
+      return `${name}: NotRequired[${definition}]${documentationSuffix}`;
+    } else {
+      state.imports.add("Optional");
+      return `${name}: NotRequired[Optional[${definition}]]${documentationSuffix}`;
+    }
   } else {
     return `${name}: ${definition}${documentationSuffix}`;
   }

--- a/src/parseProperty.ts
+++ b/src/parseProperty.ts
@@ -18,11 +18,11 @@ export const parseProperty = (state: ParserState, symbol: ts.Symbol) => {
 
   if (symbol.flags & ts.SymbolFlags.Optional) {
     state.imports.add("NotRequired");
-    if (state.config.nonNullOptionals) {
-      return `${name}: NotRequired[${definition}]${documentationSuffix}`;
-    } else {
+    if (state.config.nullableOptionals) {
       state.imports.add("Optional");
       return `${name}: NotRequired[Optional[${definition}]]${documentationSuffix}`;
+    } else {
+      return `${name}: NotRequired[${definition}]${documentationSuffix}`;
     }
   } else {
     return `${name}: ${definition}${documentationSuffix}`;

--- a/src/testing/dicts.test.ts
+++ b/src/testing/dicts.test.ts
@@ -61,15 +61,15 @@ class A(TypedDict):
 
   it("transpiles optional values as NotRequired[Optional[T]]", async () => {
     const result = await transpileString(`export type A = { foo?: string }`);
-    expect(result).toContain(
-      `class A(TypedDict):\n  foo: NotRequired[Optional[str]]`,
-    );
+    expect(result).toContain(`class A(TypedDict):\n  foo: NotRequired[str]`);
   });
 
   it("transpiles optional values with non-null optionals as NotRequired[T]", async () => {
     const result = await transpileString(`export type A = { foo?: string }`, {
-      nonNullOptionals: true,
+      nullableOptionals: true,
     });
-    expect(result).toContain(`class A(TypedDict):\n  foo: NotRequired[str]`);
+    expect(result).toContain(
+      `class A(TypedDict):\n  foo: NotRequired[Optional[str]]`,
+    );
   });
 });

--- a/src/testing/dicts.test.ts
+++ b/src/testing/dicts.test.ts
@@ -58,4 +58,18 @@ class A(TypedDict):
     );
     expect(result).toContain(`class A(TypedDict):\n  foo: str\n  bar: float`);
   });
+
+  it("transpiles optional values as NotRequired[Optional[T]]", async () => {
+    const result = await transpileString(`export type A = { foo?: string }`);
+    expect(result).toContain(
+      `class A(TypedDict):\n  foo: NotRequired[Optional[str]]`,
+    );
+  });
+
+  it("transpiles optional values with non-null optionals as NotRequired[T]", async () => {
+    const result = await transpileString(`export type A = { foo?: string }`, {
+      nonNullOptionals: true,
+    });
+    expect(result).toContain(`class A(TypedDict):\n  foo: NotRequired[str]`);
+  });
 });

--- a/src/testing/imports.test.ts
+++ b/src/testing/imports.test.ts
@@ -22,9 +22,11 @@ describe("transpiling referenced types", () => {
       );
     }
 
-    const transpiled = typeScriptToPython(program.getTypeChecker(), [
-      barSource,
-    ]);
+    const transpiled = typeScriptToPython(
+      program.getTypeChecker(),
+      [barSource],
+      {},
+    );
     expect(transpiled).toEqual(
       `from typing_extensions import TypedDict
 

--- a/src/typeScriptToPython.ts
+++ b/src/typeScriptToPython.ts
@@ -1,12 +1,13 @@
 import ts from "typescript";
-import { ParserState, createNewParserState } from "./ParserState";
+import { createNewParserState } from "./ParserState";
 import { parseExports } from "./parseExports";
+import { Ts2PyConfig } from "./config";
 
 /**
  * Transpiles the types exported by the source files into Python.
  */
-export const typeScriptToPython = (typechecker: ts.TypeChecker, sourceFiles: ts.SourceFile[]) => {
-  const state = createNewParserState(typechecker);
+export const typeScriptToPython = (typechecker: ts.TypeChecker, sourceFiles: ts.SourceFile[], config: Ts2PyConfig) => {
+  const state = createNewParserState(typechecker, config);
 
   sourceFiles.forEach((f) => {
     parseExports(state, f);


### PR DESCRIPTION
Previously, optional keys would compile to `NotRequired[Optional[T]]`, but in many scenarios (e.g. JSON serialisation) we can assume that the key either is defined or not included in the dict and simply use `NotRequired[T]`. This PR makes this the default behaviour, but adds an additional flag to revert to the old behaviour. 