### PR TITLE
Avoid double optionals in strict mode

### DIFF
--- a/src/parseProperty.ts
+++ b/src/parseProperty.ts
@@ -11,13 +11,14 @@ export const parseProperty = (state: ParserState, symbol: ts.Symbol) => {
   const documentationSuffix = documentation
     ? `\n  """\n  ${documentation.replaceAll("\n", "\n  ")}\n  """`
     : "";
-  const definition = parseInlineType(
-    state,
-    state.typechecker.getTypeOfSymbol(symbol),
-  );
-
-  if (symbol.flags & ts.SymbolFlags.Optional) {
-    state.imports.add("NotRequired");
+    
+    if (symbol.flags & ts.SymbolFlags.Optional) {
+      state.imports.add("NotRequired");
+      const definition = parseInlineType(
+        state,
+        // since the entry is already options, the inner type can be non-nullable
+        state.typechecker.getNonNullableType(state.typechecker.getTypeOfSymbol(symbol)),
+      );
     if (state.config.nullableOptionals) {
       state.imports.add("Optional");
       return `${name}: NotRequired[Optional[${definition}]]${documentationSuffix}`;
@@ -25,6 +26,11 @@ export const parseProperty = (state: ParserState, symbol: ts.Symbol) => {
       return `${name}: NotRequired[${definition}]${documentationSuffix}`;
     }
   } else {
+    const definition = parseInlineType(
+      state,
+      // since the entry is already options, the inner type can be non-nullable
+      state.typechecker.getTypeOfSymbol(symbol),
+    );
     return `${name}: ${definition}${documentationSuffix}`;
   }
 };

--- a/src/testing/dicts.test.ts
+++ b/src/testing/dicts.test.ts
@@ -64,7 +64,16 @@ class A(TypedDict):
     expect(result).toContain(`class A(TypedDict):\n  foo: NotRequired[str]`);
   });
 
-  it.only("transpiles optional values with non-null optionals as NotRequired[T]", async () => {
+  it("transpiles optional values as NotRequired[Optional[T]] in strict mode", async () => {
+    const result = await transpileString(
+      `export type A = { foo?: string }`,
+      {},
+      { strict: true },
+    );
+    expect(result).toContain(`class A(TypedDict):\n  foo: NotRequired[str]`);
+  });
+
+  it("transpiles optional values with non-null optionals as NotRequired[T]", async () => {
     const result = await transpileString(`export type A = { foo?: string }`, {
       nullableOptionals: true,
     });


### PR DESCRIPTION
This prevents emitting types containing `NotRequired[Union[None,T]]` if we don't use `--nullable-optionals`. It also re-enables accidentally skipped test cases from #19.